### PR TITLE
fix: Fixed undefined and never error

### DIFF
--- a/10 generics/src/index.ts
+++ b/10 generics/src/index.ts
@@ -1,8 +1,8 @@
 /** A FIFO (First In First Out) collection */
 class Queue<T> {
-  data = [];
+  public data:T[] = [];
   push(item: T) { this.data.push(item); }
-  pop(): T { return this.data.shift(); }
+  pop(): T { return this.data.shift()! ; } // ! signifies that it can't be undefined
 }
 
 const queue = new Queue<number>();

--- a/27 narrowing/src/index.ts
+++ b/27 narrowing/src/index.ts
@@ -9,7 +9,7 @@ type Rectangle = {
 
 type Shape = Square | Rectangle;
 
-function area(shape: Shape) {
+function area(shape: Shape): void|number {
   if ('size' in shape) {
     return shape.size * shape.size;
   }


### PR DESCRIPTION
Fixes the following errors:

Line 4: `Argument of type 'T' is not assignable to parameter of type 'never'.
`
Fixed by adding the type to data. 

Line 5: `Type 'undefined' is not assignable to type 'T'.`
  `'T' could be instantiated with an arbitrary type which could be unrelated to 'undefined'.
`


Fixed by adding an exclamation mark to the return value of pop. It signifies that the value cannot be null or undefined.